### PR TITLE
Gradle 2.1.3 fixes a privilege escalation vulnerability in 2.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'


### PR DESCRIPTION
Reviewed By: https://github.com/dchichkov
Reason: vulnerability fix propagation. manual test run.
Cherry picked from commit fdd6de5cee5ec8977b7e49548772237a948a71d1